### PR TITLE
SHOT-4257/SHOT-4266: Update for Alias and VRED

### DIFF
--- a/app.py
+++ b/app.py
@@ -180,7 +180,12 @@ class BackgroundPublisher(Application):
                 )
             )
 
-            cmd = [executable_path, "-hide_gui", "-postpython", python_cmd]
+            # VRED 2024 introduces Python Sandbox which requires authorization to run python
+            # scripts; however, the prompt to authorize is not shown when running with
+            # -hide_gui. So, we will need to add the '-insecure_python' flag to allow running
+            # our script. The alternative not using this flag, would be that the user must
+            # turn of Python Sandbox from Preferences>Scripts, or specify our module as allowed
+            cmd = [executable_path, "-hide_gui", "-insecure_python", "-postpython", python_cmd]
 
         else:
             cmd = [

--- a/app.py
+++ b/app.py
@@ -185,7 +185,13 @@ class BackgroundPublisher(Application):
             # -hide_gui. So, we will need to add the '-insecure_python' flag to allow running
             # our script. The alternative not using this flag, would be that the user must
             # turn of Python Sandbox from Preferences>Scripts, or specify our module as allowed
-            cmd = [executable_path, "-hide_gui", "-insecure_python", "-postpython", python_cmd]
+            cmd = [
+                executable_path,
+                "-hide_gui",
+                "-insecure_python",
+                "-postpython",
+                python_cmd,
+            ]
 
         else:
             cmd = [

--- a/hooks/exec_info.py
+++ b/hooks/exec_info.py
@@ -52,6 +52,8 @@ class AppUtilities(HookBaseClass):
             alias_bin_folder = os.path.dirname(sys.executable)
             if not env.get("PATH", "").startswith(alias_bin_folder):
                 env["PATH"] = "{};{}".format(alias_bin_folder, env.get("PATH", ""))
+            # Ensure tk-alias engine is running in OpenModel (headless/batch mode)
+            env["TK_ALIAS_OPEN_MODEL"] = "1"
             return env
 
         # in case of VRED, we don't want to enable the automatic ShotGrid integration in order to control the engine

--- a/scripts/run_publish_process.py
+++ b/scripts/run_publish_process.py
@@ -156,6 +156,16 @@ def main(
     log_handler = logging.FileHandler(log_path)
     sgtk.LogManager().initialize_custom_handler(log_handler)
 
+    # bootstrap the engine
+    mgr = sgtk.bootstrap.ToolkitManager()
+    mgr.plugin_id = "basic.desktop"
+    mgr.pipeline_configuration = pipeline_config_id
+    mgr.bootstrap_engine(engine_name, entity_dict)
+
+    current_engine = sgtk.platform.current_engine()
+    publish_app = current_engine.apps.get("tk-multi-publish2")
+    bg_publish_app = current_engine.apps.get("tk-multi-bg-publish")
+
     # initialize the environment
     if engine_name == "tk-maya":
         import maya.standalone
@@ -166,23 +176,11 @@ def main(
         # import pymel to be sure everything has been sourced and imported
         import pymel.core as pm
     elif engine_name == "tk-alias":
-        import alias_api
-
-        alias_api.initialize_universe()
+        alias_api = current_engine.alias_py
     elif engine_name == "tk-vred":
         import vrController
         import vrFileIO
         import vrScenegraph
-
-    # bootstrap the engine
-    mgr = sgtk.bootstrap.ToolkitManager()
-    mgr.plugin_id = "basic.desktop"
-    mgr.pipeline_configuration = pipeline_config_id
-    mgr.bootstrap_engine(engine_name, entity_dict)
-
-    current_engine = sgtk.platform.current_engine()
-    publish_app = current_engine.apps.get("tk-multi-publish2")
-    bg_publish_app = current_engine.apps.get("tk-multi-bg-publish")
 
     # load the publish tree
     # manager = publish_app.create_publish_manager(publish_logger=current_engine.logger)


### PR DESCRIPTION
* Ensure OpenModel for tk-alias via env var
* Get the Alias Python API module from the engine now instead of direct import (which will ensure the universe is already initialized)

@rob-aitchison @barbara-darkshot forgot to mention this one in our meeting