### PR TITLE
SHOT-4286: Improve debug log messages

### DIFF
--- a/python/tk_multi_bgpublish/dialog.py
+++ b/python/tk_multi_bgpublish/dialog.py
@@ -111,8 +111,6 @@ class AppDialog(QtGui.QWidget):
         :param timeout: Refresh timeout
         """
 
-        self._bundle.logger.debug("Start refreshing the model data...")
-
         if timeout:
             time.sleep(timeout)
 

--- a/python/tk_multi_bgpublish/model.py
+++ b/python/tk_multi_bgpublish/model.py
@@ -180,7 +180,7 @@ class PublishTreeModel(QtGui.QStandardItemModel, ViewItemRolesMixin):
         :param tree_file: Path to the file where the publish monitor data are stored
         """
 
-        self._bundle.logger.debug("Adding a new publish session to the model...")
+        self._bundle.logger.debug(f"Adding a new publish session to the model from {tree_file}")
 
         # create an uuid for the current session. It will be useful to gather all the tasks belonging to the same
         # session

--- a/python/tk_multi_bgpublish/model.py
+++ b/python/tk_multi_bgpublish/model.py
@@ -180,7 +180,9 @@ class PublishTreeModel(QtGui.QStandardItemModel, ViewItemRolesMixin):
         :param tree_file: Path to the file where the publish monitor data are stored
         """
 
-        self._bundle.logger.debug(f"Adding a new publish session to the model from {tree_file}")
+        self._bundle.logger.debug(
+            f"Adding a new publish session to the model from {tree_file}"
+        )
 
         # create an uuid for the current session. It will be useful to gather all the tasks belonging to the same
         # session


### PR DESCRIPTION
* Do not log a message on reload as this will clutter the UI, intead just log a message on adding a new publish session
* Update the log message on adding a new publish session to include the file path to the publish session data