### PR TITLE
SHOT-4390: Fix getting the engine object

### DIFF
--- a/scripts/run_publish_process.py
+++ b/scripts/run_publish_process.py
@@ -160,9 +160,8 @@ def main(
     mgr = sgtk.bootstrap.ToolkitManager()
     mgr.plugin_id = "basic.desktop"
     mgr.pipeline_configuration = pipeline_config_id
-    mgr.bootstrap_engine(engine_name, entity_dict)
+    current_engine = mgr.bootstrap_engine(engine_name, entity_dict)
 
-    current_engine = sgtk.platform.current_engine()
     publish_app = current_engine.apps.get("tk-multi-publish2")
     bg_publish_app = current_engine.apps.get("tk-multi-bg-publish")
 


### PR DESCRIPTION
_**This bug was introduced with the latest config using Python 3.11 - not sure if this is a bigger issue with accessing the engine through the `sgtk.platform.current_engine` method which stores the current engine as a global variable**_

* Use the engine object returned by the bootstrap method instead of relying on global variable set for the engine - this does not correctly get the engine in some cases