### PR TITLE
SHOT-4567: Fix background publish for Alias 2026.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 25.9.0
     hooks:
     - id: black
       language_version: python3

--- a/hooks/exec_info.py
+++ b/hooks/exec_info.py
@@ -6,6 +6,7 @@
 # Source Code License included in this distribution package. See LICENSE.
 
 import os
+import re
 import sys
 
 import sgtk
@@ -54,6 +55,23 @@ class AppUtilities(HookBaseClass):
                 env["PATH"] = "{};{}".format(alias_bin_folder, env.get("PATH", ""))
             # Ensure tk-alias engine is running in OpenModel (headless/batch mode)
             env["TK_ALIAS_OPEN_MODEL"] = "1"
+
+            # Set environment variables for the background publish process to import the Alias api module
+            # NOTE: this is a workaround to MSVC runtime DLL conflicts between the Alias api and PySide
+            alias_exec_path = os.environ.get("TK_ALIAS_EXECPATH")
+            if not alias_exec_path:
+                raise Exception(
+                    "Background publish for Alias requires TK_ALIAS_EXECPATH environment variable to be set"
+                )
+            env["BG_PUBLISH_ALIAS_DLL_PATH"] = os.path.dirname(alias_exec_path)
+            # Get the api path for the python version that will run the background publish process
+            api_path = os.path.dirname(current_engine.alias_py.__file__)
+            bg_publish_python_version = (
+                f"python{sys.version_info.major}.{sys.version_info.minor}"
+            )
+            api_path = re.sub(r"python\d+\.\d+", bg_publish_python_version, api_path)
+            env["BG_PUBLISH_ALIAS_API_PATH"] = api_path
+
             return env
 
         # in case of VRED, we don't want to enable the automatic Flow Production Tracking integration in order to

--- a/scripts/run_publish_process.py
+++ b/scripts/run_publish_process.py
@@ -10,7 +10,6 @@ import logging
 import os
 import sys
 
-import sgtk
 from tank_vendor import yaml
 
 
@@ -151,6 +150,41 @@ def main(
     :param monitor_file_path: Path to the file to use to monitor the publish process
     """
 
+    # Initialize environment before importing sgtk
+    if engine_name == "tk-alias":
+        # Import the Alias api module first to ensure the correct MSVC runtime DLLs are loaded
+        # NOTE: since this is not using the tk-alias engine api init, this api module will not have extensions available
+
+        # Add the api path for importing the module
+        api_path = os.environ.get("BG_PUBLISH_ALIAS_API_PATH")
+        if not api_path:
+            raise Exception(
+                "Background publish for Alias requires BG_PUBLISH_ALIAS_API_PATH environment variable to be set"
+            )
+        sys.path.insert(0, api_path)
+
+        # Add the Alias DLL path to load the Alias lib dependency for the api
+        if hasattr(os, "add_dll_directory"):
+            alias_dll_path = os.environ.get("BG_PUBLISH_ALIAS_DLL_PATH")
+            if not alias_dll_path:
+                raise Exception(
+                    "Background publish for Alias requires BG_PUBLISH_ALIAS_DLL_PATH environment variable to be set"
+                )
+            os.add_dll_directory(alias_dll_path)
+
+        # Import the Alias api module and initialize
+        try:
+            import alias_api_om as alias_api
+
+            alias_api.initialize_universe()
+        except Exception as e:
+            raise Exception(
+                f"Failed to import and initialize Alias Python API for OpenModel: {e}"
+            )
+
+    # Delay importing the sgtk module to allow importing any necessary modules before sgtk
+    import sgtk
+
     # initialize a log handler
     log_path = os.path.join(os.path.dirname(monitor_file_path), "bg_publish.log")
     log_handler = logging.FileHandler(log_path)
@@ -174,8 +208,6 @@ def main(
 
         # import pymel to be sure everything has been sourced and imported
         import pymel.core as pm
-    elif engine_name == "tk-alias":
-        alias_api = current_engine.alias_py
     elif engine_name == "tk-vred":
         import vrController
         import vrFileIO


### PR DESCRIPTION
_**Workaround until FPT Desktop ships PySide version >= 6.8**_

* Alias 2026.1 has a MSVC runtime DLL conflict with PySide 6.5 which prevents the alias_api module from loading
* Add workaround to force loading the alias_api module first, before sgtk which loads PySide