### PR TITLE
SHOT-4585: Update bg publish for Alias 2027.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 25.9.0
+    rev: 26.1.0
     hooks:
     - id: black
       language_version: python3

--- a/hooks/exec_info.py
+++ b/hooks/exec_info.py
@@ -72,6 +72,37 @@ class AppUtilities(HookBaseClass):
             api_path = re.sub(r"python\d+\.\d+", bg_publish_python_version, api_path)
             env["BG_PUBLISH_ALIAS_API_PATH"] = api_path
 
+            # Get the Alias license info and set the environment variables for
+            # the background publish process. The background process will use
+            # the Alias OpenModel API, which requires setting the license info,
+            # starting in Alias 2027.0
+            alias_lic_info = current_engine.alias_py.get_product_information()
+            product_key = alias_lic_info.get("product_key")
+            product_version = alias_lic_info.get("product_version")
+            product_license_type = alias_lic_info.get("product_license_type")
+            product_license_path = alias_lic_info.get("product_license_path")
+
+            if not all(
+                [
+                    product_key,
+                    product_version,
+                    product_license_type,
+                    product_license_path,
+                ]
+            ):
+                raise Exception(
+                    f"""Missing Alias license informatin required for background publish:
+                    product_key: {product_key}
+                    product_version: {product_version}
+                    product_license_type: {product_license_type}
+                    product_license_path: {product_license_path}
+                    """
+                )
+            env["BG_PUBLISH_ALIAS_PRODUCT_KEY"] = product_key
+            env["BG_PUBLISH_ALIAS_PRODUCT_VERSION"] = product_version
+            env["BG_PUBLISH_ALIAS_PRODUCT_LIC_TYPE"] = product_license_type
+            env["BG_PUBLISH_ALIAS_PRODUCT_LIC_PATH"] = product_license_path
+
             return env
 
         # in case of VRED, we don't want to enable the automatic Flow Production Tracking integration in order to

--- a/python/tk_multi_bgpublish/model.py
+++ b/python/tk_multi_bgpublish/model.py
@@ -37,7 +37,7 @@ class PublishTreeModel(QtGui.QStandardItemModel, ViewItemRolesMixin):
         NEXT_AVAILABLE_ROLE,
     ) = range(_BASE_ROLE, _BASE_ROLE + 10)
 
-    (PUBLISH_SESSION, PUBLISH_ITEM, PUBLISH_TASK) = range(3)
+    PUBLISH_SESSION, PUBLISH_ITEM, PUBLISH_TASK = range(3)
 
     TOOLTIP_TEXT = {
         constants.WAITING_TO_START: "The publish job is waiting to start",

--- a/scripts/run_publish_process.py
+++ b/scripts/run_publish_process.py
@@ -152,7 +152,7 @@ def main(
 
     # Initialize environment before importing sgtk
     if engine_name == "tk-alias":
-        # Import the Alias api module first to ensure the correct MSVC runtime DLLs are loaded
+        # Import the Alias api module before sgtk to ensure the correct MSVC runtime DLLs are loaded
         # NOTE: since this is not using the tk-alias engine api init, this api module will not have extensions available
 
         # Add the api path for importing the module
@@ -176,7 +176,45 @@ def main(
         try:
             import alias_api_om as alias_api
 
-            alias_api.initialize_universe()
+            # Starting in Alias 2027.0, using OpenModel API requires setting the
+            # license information before initializing the universe
+            if hasattr(alias_api, "set_license_information"):
+                product_key = os.environ.get("BG_PUBLISH_ALIAS_PRODUCT_KEY", "")
+                product_version = os.environ.get("BG_PUBLISH_ALIAS_PRODUCT_VERSION", "")
+                product_lic_type = os.environ.get(
+                    "BG_PUBLISH_ALIAS_PRODUCT_LIC_TYPE", ""
+                )
+                product_lic_path = os.environ.get(
+                    "BG_PUBLISH_ALIAS_PRODUCT_LIC_PATH", ""
+                )
+                status = alias_api.set_license_information(
+                    product_key,
+                    product_version,
+                    product_lic_type,
+                    product_lic_path,
+                )
+                if status != alias_api.AlStatusCode.Success.value:
+                    raise Exception(
+                        f"""Failed to set Alias license info. Status code: {status}
+                        product_key: {product_key}
+                        product_version: {product_version}
+                        product_lic_type: {product_lic_type}
+                        product_lic_path: {product_lic_path}
+                        """
+                    )
+
+            # Initialize the Alias universe before using the API
+            init_status = alias_api.initialize_universe()
+            if hasattr(alias_api, "is_initialized"):
+                if not alias_api.is_initialized():
+                    raise Exception(
+                        f"Failed to initialize Alias universe. Status code: {init_status}"
+                    )
+            elif init_status == alias_api.AlStatusCode.Failure.value:
+                raise Exception(
+                    f"Failed to initialize Alias universe. Status code: {init_status}"
+                )
+
         except Exception as e:
             raise Exception(
                 f"Failed to import and initialize Alias Python API for OpenModel: {e}"


### PR DESCRIPTION
* 2027.0 now requires license info to be set before accessing the API in OpenModel
* Set the license info before the bg process is launched in env vars; the bg process will access the license info via the env while executing