### PR TITLE
SG-43664 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -35,6 +35,7 @@ description: "Provides UI and functionality to launch and monitor background pub
 requires_shotgun_version: "v6.2.0"
 requires_core_version: "v0.18.45"
 requires_engine_version:
+minimum_python_version: "3.9"
 
 # the frameworks required to run this app
 frameworks:

--- a/python/tk_multi_bgpublish/model.py
+++ b/python/tk_multi_bgpublish/model.py
@@ -171,7 +171,7 @@ class PublishTreeModel(QtGui.QStandardItemModel, ViewItemRolesMixin):
         # be sure to remove all the stored items
         self.__tasks = []
 
-        super(PublishTreeModel, self).clear()
+        super().clear()
 
     def add_publish_tree(self, tree_file):
         """


### PR DESCRIPTION
## Summary
- Set `minimum_python_version: "3.9"` in `info.yml`
- Modernised `super()` call in `model.py`

## Test plan
- [ ] Pre-commit passes (black, check-ast, check-yaml, whitespace)
- [ ] Background publish launches and completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)